### PR TITLE
Source global definitions as Jenkins user on Euler

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -14,12 +14,14 @@ elif [[ "${HOSTNAME}" == daint* ]]; then
 elif [[ "${HOSTNAME}" == dom* ]]; then 
     BASHRC_HOST='dom'
 elif [[ "${HOSTNAME}" == eu* ]]; then 
-
     if tty -s; then
         BASHRC_HOST='euler'
 
-    # do nothing for me as Jenkins user
+    # Source global definitions as Jenkins user
     else
+        if [ -f /etc/bashrc ]; then
+            . /etc/bashrc
+        fi
         return
     fi
 elif [[ "${HOSTNAME}" == *levante* ]]; then 


### PR DESCRIPTION
This should fix the Jenkins plan for Euler. Check also your local `~/.bash_profile`.